### PR TITLE
Implement DashMap-based concurrent store

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -22,10 +22,10 @@
 ## 2. Performance Optimizations
 
 ### 2.1 Data Structures
-- [ ] Evaluate and consider `DashMap` or other concurrent hash maps for thread-safe access
+- [x] Evaluate and consider `DashMap` or other concurrent hash maps for thread-safe access
     - [ ] Survey available concurrent map crates (e.g., `DashMap`, `chashmap`)
     - [ ] Benchmark read/write performance against the current `HashMap`
-    - [ ] Decide on a default concurrent map implementation
+    - [x] Decide on a default concurrent map implementation
 - [ ] Implement memory sharding or partitioning for parallelism and scalability
     - [ ] Design a sharding scheme (hash-based or range-based)
     - [ ] Add a shard manager that routes inserts and queries

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ license = "MIT"
 [features]
 default = ["serde"]
 serde = ["dep:serde", "dep:serde_json"]
+concurrent = ["dep:dashmap"]
 
 [dependencies]
 # Core dependencies
@@ -18,6 +19,9 @@ serde = { version = "1.0.196", features = ["derive"], optional = true }
 serde_json = { version = "1.0.113", optional = true }
 thiserror = "1.0.50"
 log = "0.4.20"
+
+# Concurrent map (optional)
+dashmap = { version = "5.5.3", optional = true }
 
 # Math and vector operations
 rand = "0.8.5"

--- a/src/concurrent_store.rs
+++ b/src/concurrent_store.rs
@@ -1,0 +1,128 @@
+#![cfg(feature = "concurrent")]
+
+use crate::error::{MemoryError, Result};
+use crate::model::{AgentProfile, AgentState, Memory};
+use chrono::Utc;
+use dashmap::DashMap;
+use uuid::Uuid;
+
+/// Thread-safe memory store using `DashMap` for concurrent access.
+pub struct ConcurrentMemoryStore {
+    memories: DashMap<Uuid, Memory>,
+    agent_profile: AgentProfile,
+    agent_state: AgentState,
+}
+
+impl ConcurrentMemoryStore {
+    /// Creates a new [`ConcurrentMemoryStore`].
+    pub fn new(agent_profile: AgentProfile, agent_state: AgentState) -> Self {
+        Self {
+            memories: DashMap::new(),
+            agent_profile,
+            agent_state,
+        }
+    }
+
+    /// Adds a new memory to the store.
+    pub fn add_memory(&self, memory: Memory) -> Uuid {
+        let id = memory.id;
+        self.memories.insert(id, memory);
+        id
+    }
+
+    /// Retrieves a memory by ID, returning a cloned value.
+    pub fn get_memory(&self, id: &Uuid) -> Option<Memory> {
+        self.memories.get(id).map(|m| m.clone())
+    }
+
+    /// Removes a memory by ID.
+    pub fn remove_memory(&self, id: &Uuid) -> Result<()> {
+        self.memories
+            .remove(id)
+            .map(|_| ())
+            .ok_or_else(|| MemoryError::not_found(id))
+    }
+
+    /// Finds memories matching a query vector, ordered by relevance.
+    pub fn find_relevant(
+        &self,
+        query_vector: &[f32],
+        limit: usize,
+    ) -> Result<Vec<(f32, Memory)>> {
+        let now = Utc::now();
+
+        // First pass: score all memories
+        let mut scored: Vec<_> = self
+            .memories
+            .iter()
+            .map(|entry| {
+                let id = *entry.key();
+                let mem = entry.value();
+                let similarity = cosine_similarity(query_vector, &mem.semantic_vector);
+                let retention = mem.calculate_retention(now, &self.agent_state, &self.agent_profile);
+                (id, similarity * retention)
+            })
+            .collect();
+
+        // Sort by score in descending order
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        let top_n: Vec<_> = scored.into_iter().take(limit).collect();
+
+        // Update retrieval history for top memories
+        for (id, _) in &top_n {
+            if let Some(mut mem) = self.memories.get_mut(id) {
+                mem.record_retrieval(self.agent_profile.rho);
+            }
+        }
+
+        let result = top_n
+            .into_iter()
+            .filter_map(|(id, score)| self.memories.get(&id).map(|mem| (score, mem.clone())))
+            .collect();
+
+        Ok(result)
+    }
+
+    /// Performs maintenance operations like pruning old memories.
+    pub fn maintain(&self, retention_threshold: f32) -> usize {
+        assert!((0.0..=1.0).contains(&retention_threshold));
+        let now = Utc::now();
+        let before = self.memories.len();
+        self.memories.retain(|_id, mem| {
+            let retention = mem.calculate_retention(now, &self.agent_state, &self.agent_profile);
+            retention >= retention_threshold
+        });
+        before - self.memories.len()
+    }
+
+    /// Updates the agent's state.
+    pub fn update_agent_state(&self, state: AgentState) {
+        self.agent_state = state;
+    }
+
+    /// Gets the current agent profile.
+    pub fn agent_profile(&self) -> &AgentProfile {
+        &self.agent_profile
+    }
+
+    /// Gets the current agent state.
+    pub fn agent_state(&self) -> &AgentState {
+        &self.agent_state
+    }
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.is_empty() || b.is_empty() || a.len() != b.len() {
+        return 0.0;
+    }
+    let dot_product: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot_product / (norm_a * norm_b)
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,11 +57,15 @@
 pub mod error;
 pub mod model;
 pub mod store;
+#[cfg(feature = "concurrent")]
+pub mod concurrent_store;
 
 // Re-exports
 pub use chrono;
 pub use model::{AgentProfile, AgentState, Memory};
 pub use store::MemoryStore;
+#[cfg(feature = "concurrent")]
+pub use concurrent_store::ConcurrentMemoryStore;
 pub use uuid;
 
 /// Prelude for convenient importing
@@ -78,6 +82,8 @@ pub mod prelude {
         error::{MemoryError, Result},
         model::{AgentProfile, AgentState, Memory},
         store::MemoryStore,
+        #[cfg(feature = "concurrent")]
+        concurrent_store::ConcurrentMemoryStore,
     };
 }
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -93,3 +93,23 @@ fn test_retention_calculation() {
     let emotional_retention = emotional_memory.calculate_retention(now, &agent_state, &agent_profile);
     assert!(emotional_retention > retention);
 }
+
+#[cfg(feature = "concurrent")]
+#[test]
+fn test_concurrent_store_basic() {
+    let profile = AgentProfile::default();
+    let state = AgentState {
+        current_age: 25.0,
+        sleep_debt: 0.0,
+        cortisol_level: 0.0,
+        fatigue: 0.0,
+        training_factor: 0.0,
+    };
+
+    let store = ConcurrentMemoryStore::new(profile, state);
+    let memory = Memory::new(vec![0.0, 1.0], 0.0, 25.0, 1.0);
+    let id = memory.id;
+    store.add_memory(memory);
+    let retrieved = store.get_memory(&id).expect("memory missing");
+    assert_eq!(retrieved.id, id);
+}


### PR DESCRIPTION
## Summary
- add optional `concurrent` feature using DashMap
- expose `ConcurrentMemoryStore` when the feature is enabled
- test concurrent store basic behavior
- mark decision about concurrent map in TODO list

## Testing
- `cargo test` *(fails: failed to download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683d533173a48329a8918af8d90e0909