### PR TITLE
Implement sharded memory store

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -26,10 +26,10 @@
     - [ ] Survey available concurrent map crates (e.g., `DashMap`, `chashmap`)
     - [ ] Benchmark read/write performance against the current `HashMap`
     - [x] Decide on a default concurrent map implementation
-- [ ] Implement memory sharding or partitioning for parallelism and scalability
-    - [ ] Design a sharding scheme (hash-based or range-based)
-    - [ ] Add a shard manager that routes inserts and queries
-    - [ ] Provide APIs for cross-shard iteration and maintenance
+- [x] Implement memory sharding or partitioning for parallelism and scalability
+    - [x] Design a sharding scheme (hash-based or range-based)
+    - [x] Add a shard manager that routes inserts and queries
+    - [x] Provide APIs for cross-shard iteration and maintenance
 - [ ] Add benchmarking to measure performance of different data structures
     - [ ] Set up `criterion` benchmarks for store operations
     - [ ] Compare baseline performance with alternative data structures

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ pub mod model;
 pub mod store;
 #[cfg(feature = "concurrent")]
 pub mod concurrent_store;
+#[cfg(feature = "concurrent")]
+pub mod sharded_store;
 
 // Re-exports
 pub use chrono;
@@ -66,6 +68,8 @@ pub use model::{AgentProfile, AgentState, Memory};
 pub use store::MemoryStore;
 #[cfg(feature = "concurrent")]
 pub use concurrent_store::ConcurrentMemoryStore;
+#[cfg(feature = "concurrent")]
+pub use sharded_store::ShardedMemoryStore;
 pub use uuid;
 
 /// Prelude for convenient importing
@@ -84,6 +88,8 @@ pub mod prelude {
         store::MemoryStore,
         #[cfg(feature = "concurrent")]
         concurrent_store::ConcurrentMemoryStore,
+        #[cfg(feature = "concurrent")]
+        sharded_store::ShardedMemoryStore,
     };
 }
 

--- a/src/sharded_store.rs
+++ b/src/sharded_store.rs
@@ -1,0 +1,138 @@
+#![cfg(feature = "concurrent")]
+
+use crate::error::{MemoryError, Result};
+use crate::model::{AgentProfile, AgentState, Memory};
+use chrono::Utc;
+use dashmap::DashMap;
+use uuid::Uuid;
+
+/// Memory store that partitions data across multiple shards for scalability.
+pub struct ShardedMemoryStore {
+    shards: Vec<DashMap<Uuid, Memory>>,
+    agent_profile: AgentProfile,
+    agent_state: AgentState,
+}
+
+impl ShardedMemoryStore {
+    /// Creates a new [`ShardedMemoryStore`] with the specified number of shards.
+    pub fn new(agent_profile: AgentProfile, agent_state: AgentState, num_shards: usize) -> Self {
+        assert!(num_shards > 0, "num_shards must be greater than 0");
+        let shards = (0..num_shards).map(|_| DashMap::new()).collect();
+        Self {
+            shards,
+            agent_profile,
+            agent_state,
+        }
+    }
+
+    fn shard_index(&self, id: &Uuid) -> usize {
+        (id.as_u128() as usize) % self.shards.len()
+    }
+
+    /// Adds a new memory to the appropriate shard.
+    pub fn add_memory(&self, memory: Memory) -> Uuid {
+        let id = memory.id;
+        let idx = self.shard_index(&id);
+        self.shards[idx].insert(id, memory);
+        id
+    }
+
+    /// Retrieves a memory by ID, returning a cloned value.
+    pub fn get_memory(&self, id: &Uuid) -> Option<Memory> {
+        let idx = self.shard_index(id);
+        self.shards[idx].get(id).map(|m| m.clone())
+    }
+
+    /// Removes a memory by ID.
+    pub fn remove_memory(&self, id: &Uuid) -> Result<()> {
+        let idx = self.shard_index(id);
+        self.shards[idx]
+            .remove(id)
+            .map(|_| ())
+            .ok_or_else(|| MemoryError::not_found(id))
+    }
+
+    /// Finds memories matching a query vector, ordered by relevance across all shards.
+    pub fn find_relevant(&self, query_vector: &[f32], limit: usize) -> Result<Vec<(f32, Memory)>> {
+        let now = Utc::now();
+        let mut scored: Vec<_> = self
+            .shards
+            .iter()
+            .flat_map(|shard| {
+                shard.iter().map(|entry| {
+                    let id = *entry.key();
+                    let mem = entry.value();
+                    let similarity = cosine_similarity(query_vector, &mem.semantic_vector);
+                    let retention = mem.calculate_retention(now, &self.agent_state, &self.agent_profile);
+                    (id, similarity * retention)
+                })
+            })
+            .collect();
+
+        scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+        let top_n: Vec<_> = scored.into_iter().take(limit).collect();
+
+        for (id, _) in &top_n {
+            let idx = self.shard_index(id);
+            if let Some(mut mem) = self.shards[idx].get_mut(id) {
+                mem.record_retrieval(self.agent_profile.rho);
+            }
+        }
+
+        let result = top_n
+            .into_iter()
+            .filter_map(|(id, score)| {
+                let idx = self.shard_index(&id);
+                self.shards[idx].get(&id).map(|mem| (score, mem.clone()))
+            })
+            .collect();
+
+        Ok(result)
+    }
+
+    /// Performs maintenance operations like pruning old memories on all shards.
+    pub fn maintain(&self, retention_threshold: f32) -> usize {
+        assert!((0.0..=1.0).contains(&retention_threshold));
+        let now = Utc::now();
+        let mut total_pruned = 0;
+        for shard in &self.shards {
+            let before = shard.len();
+            shard.retain(|_id, mem| {
+                let retention = mem.calculate_retention(now, &self.agent_state, &self.agent_profile);
+                retention >= retention_threshold
+            });
+            total_pruned += before - shard.len();
+        }
+        total_pruned
+    }
+
+    /// Updates the agent's state.
+    pub fn update_agent_state(&self, state: AgentState) {
+        self.agent_state = state;
+    }
+
+    /// Returns a reference to the agent profile.
+    pub fn agent_profile(&self) -> &AgentProfile {
+        &self.agent_profile
+    }
+
+    /// Returns a reference to the agent state.
+    pub fn agent_state(&self) -> &AgentState {
+        &self.agent_state
+    }
+}
+
+fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.is_empty() || b.is_empty() || a.len() != b.len() {
+        return 0.0;
+    }
+    let dot_product: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot_product / (norm_a * norm_b)
+    }
+}
+

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -113,3 +113,23 @@ fn test_concurrent_store_basic() {
     let retrieved = store.get_memory(&id).expect("memory missing");
     assert_eq!(retrieved.id, id);
 }
+
+#[cfg(feature = "concurrent")]
+#[test]
+fn test_sharded_store_basic() {
+    let profile = AgentProfile::default();
+    let state = AgentState {
+        current_age: 25.0,
+        sleep_debt: 0.0,
+        cortisol_level: 0.0,
+        fatigue: 0.0,
+        training_factor: 0.0,
+    };
+
+    let store = ShardedMemoryStore::new(profile, state, 4);
+    let memory = Memory::new(vec![1.0, 0.0], 0.0, 25.0, 1.0);
+    let id = memory.id;
+    store.add_memory(memory);
+    let retrieved = store.get_memory(&id).expect("missing");
+    assert_eq!(retrieved.id, id);
+}


### PR DESCRIPTION
## Summary
- add `ShardedMemoryStore` as a DashMap-based sharded store
- re-export new store in the library prelude
- add basic test for sharded store
- mark sharding tasks as complete in TODO list

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683d559c0528832989fe7b5243b58c26