### PR TITLE
Add batch similarity search support

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -40,7 +40,7 @@
 ### 2.2 Similarity Search
 - [ ] Integrate FAISS, HNSWlib, or other optimized ANN libraries
 - [ ] Add SIMD optimizations for vector operations (e.g., `packed_simd` or intrinsics)
-- [ ] Implement batch processing for bulk similarity search operations
+- [x] Implement batch processing for bulk similarity search operations
 - [ ] Evaluate and compare different indexing strategies (e.g., IVFADC, SCANN)
 
 ## 3. Persistence Layer

--- a/src/concurrent_store.rs
+++ b/src/concurrent_store.rs
@@ -84,6 +84,18 @@ impl ConcurrentMemoryStore {
         Ok(result)
     }
 
+    /// Finds relevant memories for multiple query vectors in a single call.
+    pub fn find_relevant_batch(
+        &self,
+        query_vectors: &[Vec<f32>],
+        limit: usize,
+    ) -> Result<Vec<Vec<(f32, Memory)>>> {
+        query_vectors
+            .iter()
+            .map(|q| self.find_relevant(q, limit))
+            .collect()
+    }
+
     /// Performs maintenance operations like pruning old memories.
     pub fn maintain(&self, retention_threshold: f32) -> usize {
         assert!((0.0..=1.0).contains(&retention_threshold));

--- a/src/sharded_store.rs
+++ b/src/sharded_store.rs
@@ -90,6 +90,18 @@ impl ShardedMemoryStore {
         Ok(result)
     }
 
+    /// Finds relevant memories for multiple query vectors across all shards.
+    pub fn find_relevant_batch(
+        &self,
+        query_vectors: &[Vec<f32>],
+        limit: usize,
+    ) -> Result<Vec<Vec<(f32, Memory)>>> {
+        query_vectors
+            .iter()
+            .map(|q| self.find_relevant(q, limit))
+            .collect()
+    }
+
     /// Performs maintenance operations like pruning old memories on all shards.
     pub fn maintain(&self, retention_threshold: f32) -> usize {
         assert!((0.0..=1.0).contains(&retention_threshold));

--- a/src/store.rs
+++ b/src/store.rs
@@ -123,6 +123,21 @@ impl MemoryStore {
         Ok(result)
     }
 
+    /// Finds relevant memories for multiple query vectors in a single call.
+    ///
+    /// This is a convenience wrapper that iterates over each query vector and
+    /// returns a vector of results per query.
+    pub fn find_relevant_batch(
+        &mut self,
+        query_vectors: &[Vec<f32>],
+        limit: usize,
+    ) -> Result<Vec<Vec<(f32, Memory)>>> {
+        query_vectors
+            .iter()
+            .map(|q| self.find_relevant(q, limit))
+            .collect()
+    }
+
     /// Performs maintenance operations like pruning old memories.
     ///
     /// Returns the number of memories that were pruned.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -94,6 +94,29 @@ fn test_retention_calculation() {
     assert!(emotional_retention > retention);
 }
 
+#[test]
+fn test_find_relevant_batch() {
+    let profile = AgentProfile::default();
+    let state = AgentState {
+        current_age: 25.0,
+        sleep_debt: 0.0,
+        cortisol_level: 0.0,
+        fatigue: 0.0,
+        training_factor: 0.0,
+    };
+
+    let mut store = MemoryStore::new(profile, state);
+    store.add_memory(Memory::new(vec![0.1, 0.2, 0.3], 0.0, 25.0, 1.0));
+    store.add_memory(Memory::new(vec![0.2, 0.3, 0.4], 0.0, 25.0, 1.0));
+
+    let queries = vec![vec![0.1, 0.2, 0.3], vec![0.2, 0.3, 0.4]];
+    let results = store.find_relevant_batch(&queries, 1).unwrap();
+
+    assert_eq!(results.len(), 2);
+    assert_eq!(results[0].len(), 1);
+    assert_eq!(results[1].len(), 1);
+}
+
 #[cfg(feature = "concurrent")]
 #[test]
 fn test_concurrent_store_basic() {


### PR DESCRIPTION
## Summary
- add `find_relevant_batch` to `MemoryStore`
- add concurrent and sharded versions of batch search
- exercise new API in tests
- check off related TODO item

## Testing
- `cargo test` *(fails: could not connect to crates.io)*

------
https://chatgpt.com/codex/tasks/task_e_683e079e2eac8329a11636f4b9776330