### PR TITLE
Add SIMD cosine similarity

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -39,7 +39,7 @@
 
 ### 2.2 Similarity Search
 - [ ] Integrate FAISS, HNSWlib, or other optimized ANN libraries
-- [ ] Add SIMD optimizations for vector operations (e.g., `packed_simd` or intrinsics)
+- [x] Add SIMD optimizations for vector operations (e.g., `packed_simd` or intrinsics)
 - [ ] Implement batch processing for bulk similarity search operations
 - [ ] Evaluate and compare different indexing strategies (e.g., IVFADC, SCANN)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 default = ["serde"]
 serde = ["dep:serde", "dep:serde_json"]
 concurrent = ["dep:dashmap"]
+simd = []
 
 [dependencies]
 # Core dependencies

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-memory-module = { path = "./memory-module", features = ["serde"] }
+memory-module = { path = "./memory-module", features = ["serde", "simd"] }
 ```
 
 ### Example
@@ -66,6 +66,12 @@ store.add_memory(memory);
 let query = vec![0.15, 0.25, 0.35];
 let relevant = store.find_relevant(&query, 5).unwrap();
 ```
+
+## Cargo Features
+
+- `serde` - enable serialization and deserialization
+- `concurrent` - provide thread-safe memory stores
+- `simd` - accelerate vector operations with SIMD instructions
 
 ## Running Examples
 

--- a/src/concurrent_store.rs
+++ b/src/concurrent_store.rs
@@ -113,16 +113,6 @@ impl ConcurrentMemoryStore {
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.is_empty() || b.is_empty() || a.len() != b.len() {
-        return 0.0;
-    }
-    let dot_product: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
-        0.0
-    } else {
-        dot_product / (norm_a * norm_b)
-    }
+    crate::simd::cosine_similarity(a, b)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,6 +61,7 @@ pub mod store;
 pub mod concurrent_store;
 #[cfg(feature = "concurrent")]
 pub mod sharded_store;
+mod simd;
 
 // Re-exports
 pub use chrono;

--- a/src/sharded_store.rs
+++ b/src/sharded_store.rs
@@ -123,16 +123,6 @@ impl ShardedMemoryStore {
 }
 
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.is_empty() || b.is_empty() || a.len() != b.len() {
-        return 0.0;
-    }
-    let dot_product: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    if norm_a == 0.0 || norm_b == 0.0 {
-        0.0
-    } else {
-        dot_product / (norm_a * norm_b)
-    }
+    crate::simd::cosine_similarity(a, b)
 }
 

--- a/src/simd.rs
+++ b/src/simd.rs
@@ -1,0 +1,79 @@
+//! SIMD-accelerated vector operations.
+//!
+//! This module provides optimized implementations for common vector
+//! calculations using architecture intrinsics when the `simd` feature
+//! is enabled. If SIMD is not available or the feature is disabled,
+//! scalar fallbacks are used instead.
+
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+use std::arch::x86_64::*;
+
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+#[target_feature(enable = "sse2")]
+unsafe fn cosine_similarity_simd(a: &[f32], b: &[f32]) -> f32 {
+    if a.is_empty() || b.is_empty() || a.len() != b.len() {
+        return 0.0;
+    }
+
+    let mut sum = _mm_setzero_ps();
+    let mut sum_a = _mm_setzero_ps();
+    let mut sum_b = _mm_setzero_ps();
+    let chunks = a.len() / 4;
+    let ptr_a = a.as_ptr();
+    let ptr_b = b.as_ptr();
+    for i in 0..chunks {
+        let va = _mm_loadu_ps(ptr_a.add(i * 4));
+        let vb = _mm_loadu_ps(ptr_b.add(i * 4));
+        sum = _mm_add_ps(sum, _mm_mul_ps(va, vb));
+        sum_a = _mm_add_ps(sum_a, _mm_mul_ps(va, va));
+        sum_b = _mm_add_ps(sum_b, _mm_mul_ps(vb, vb));
+    }
+
+    let mut dot_arr = [0f32; 4];
+    let mut norm_a_arr = [0f32; 4];
+    let mut norm_b_arr = [0f32; 4];
+    _mm_storeu_ps(dot_arr.as_mut_ptr(), sum);
+    _mm_storeu_ps(norm_a_arr.as_mut_ptr(), sum_a);
+    _mm_storeu_ps(norm_b_arr.as_mut_ptr(), sum_b);
+
+    let mut dot = dot_arr.iter().sum::<f32>();
+    let mut norm_a = norm_a_arr.iter().sum::<f32>();
+    let mut norm_b = norm_b_arr.iter().sum::<f32>();
+
+    for i in (chunks * 4)..a.len() {
+        let x = *a.get_unchecked(i);
+        let y = *b.get_unchecked(i);
+        dot += x * y;
+        norm_a += x * x;
+        norm_b += y * y;
+    }
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot / (norm_a.sqrt() * norm_b.sqrt())
+    }
+}
+
+#[cfg(all(feature = "simd", target_arch = "x86_64"))]
+pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    // SAFETY: function uses SSE2 instructions which are available on x86_64
+    unsafe { cosine_similarity_simd(a, b) }
+}
+
+#[cfg(any(not(feature = "simd"), not(target_arch = "x86_64")))]
+pub(crate) fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.is_empty() || b.is_empty() || a.len() != b.len() {
+        return 0.0;
+    }
+
+    let dot_product: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
+    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
+    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
+
+    if norm_a == 0.0 || norm_b == 0.0 {
+        0.0
+    } else {
+        dot_product / (norm_a * norm_b)
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -166,19 +166,7 @@ impl MemoryStore {
 ///
 /// Returns `0.0` if the vectors are empty or their lengths differ.
 fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
-    if a.is_empty() || b.is_empty() || a.len() != b.len() {
-        return 0.0;
-    }
-
-    let dot_product: f32 = a.iter().zip(b).map(|(&x, &y)| x * y).sum();
-    let norm_a: f32 = a.iter().map(|&x| x * x).sum::<f32>().sqrt();
-    let norm_b: f32 = b.iter().map(|&x| x * x).sum::<f32>().sqrt();
-
-    if norm_a == 0.0 || norm_b == 0.0 {
-        0.0
-    } else {
-        dot_product / (norm_a * norm_b)
-    }
+    crate::simd::cosine_similarity(a, b)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add optional `simd` feature
- implement SIMD-accelerated cosine similarity using SSE2
- use the SIMD implementation across all store types
- document the new `simd` Cargo feature
- mark the TODO item for SIMD optimizations as done

## Testing
- `cargo test --quiet` *(fails: failed to get `chrono` as a dependency)*
- `cargo fmt -- --check` *(fails: rustfmt not installed)*
- `cargo clippy -- -D warnings` *(fails: clippy not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683e077d62f48329a214d5429a0a6cb4