### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions-rs/toolchain@v1
@@ -25,6 +27,8 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
     if: github.ref_type == 'tag'
     steps:
       - uses: actions/configure-pages@v2


### PR DESCRIPTION
Potential fix for [https://github.com/AlexanderDaly/memory-module/security/code-scanning/2](https://github.com/AlexanderDaly/memory-module/security/code-scanning/2)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow:
- The `build` job requires `contents: read` to interact with repository contents.
- The `deploy` job requires `pages: write` to deploy GitHub Pages.

The `permissions` block can be added at the root level to apply to all jobs or at the job level for more granular control. In this case, job-specific permissions are recommended for better security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
