### PR TITLE
Add property-based tests

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -76,7 +76,7 @@
 ## 5. Testing Strategy
 
 ### 5.1 Test Coverage
-- [ ] Add property-based tests (`proptest`, `quickcheck`) for core algorithms/data structures
+- [x] Add property-based tests (`proptest`, `quickcheck`) for core algorithms/data structures
 - [ ] Improve integration test coverage for component interactions
 - [x] Add benchmark tests (`criterion.rs`) to track performance and prevent regressions
 - [ ] Aim for high code coverage (>80-90%) using `cargo-tarpaulin` or `grcov`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,4 @@ rstest = "0.18.2"
 approx = "0.5.1"
 env_logger = "0.11.3"
 criterion = { version = "0.5", features = ["html_reports"] }
+proptest = "1.4.0"

--- a/src/model.rs
+++ b/src/model.rs
@@ -304,9 +304,9 @@ impl Memory {
         };
         
         // Capacity competition
-        let c_max = agent_profile.c_base * 
+        let c_max = profile.c_base *
             (1.0 - agent_state.fatigue + agent_state.training_factor);
-        let cap_comp = (self.capacity_weight.min(c_max) / agent_profile.c_base).max(0.0);
+        let cap_comp = (self.capacity_weight.min(c_max) / profile.c_base).max(0.0);
         
         // Interference (simplified - would use ANN in production)
         // For now, we'll use a placeholder value

--- a/tests/property_tests.rs
+++ b/tests/property_tests.rs
@@ -1,0 +1,25 @@
+use memory_module::simd_utils;
+use proptest::prelude::*;
+
+proptest! {
+    #[test]
+    fn cosine_similarity_is_symmetric(a in proptest::collection::vec(-1.0f32..1.0, 0..8),
+                                      b in proptest::collection::vec(-1.0f32..1.0, 0..8)) {
+        let ab = simd_utils::cosine_similarity(&a, &b);
+        let ba = simd_utils::cosine_similarity(&b, &a);
+        prop_assert!((ab - ba).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_similarity_self_is_one(v in proptest::collection::vec(-1.0f32..1.0, 1..8)) {
+        let cs = simd_utils::cosine_similarity(&v, &v);
+        prop_assert!((cs - 1.0).abs() < 1e-5);
+    }
+
+    #[test]
+    fn cosine_similarity_in_range(a in proptest::collection::vec(-1.0f32..1.0, 0..8),
+                                  b in proptest::collection::vec(-1.0f32..1.0, 0..8)) {
+        let cs = simd_utils::cosine_similarity(&a, &b);
+        prop_assert!(cs >= -1.0 && cs <= 1.0);
+    }
+}


### PR DESCRIPTION
## Summary
- fix bug in `Memory::calculate_retention`
- add `proptest` dev dependency
- implement property-based tests for cosine similarity
- mark property-based tests task complete in todo list

## Testing
- `cargo test --offline` *(fails: no matching package named `chrono` found)*

------
https://chatgpt.com/codex/tasks/task_e_683e81c60d508329a1597f6c90268f8f