### PR TITLE
Add Save/Load persistence traits

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -47,7 +47,7 @@
 
 ### 3.1 Serialization
 - [x] Add `serde` support for all core types
-- [ ] Implement `Save`/`Load` traits for the main memory store and components
+- [x] Implement `Save`/`Load` traits for the main memory store and components
 - [ ] Add support for multiple storage backends (local file, object storage, databases)
 - [ ] Implement data format versioning for backward/forward compatibility
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,7 @@ pub mod concurrent_store;
 pub mod sharded_store;
 #[cfg(any(feature = "faiss"))]
 pub mod faiss_index;
+pub mod persistence;
 
 // Re-exports
 pub use chrono;
@@ -73,6 +74,7 @@ pub use store::MemoryStore;
 pub use concurrent_store::ConcurrentMemoryStore;
 #[cfg(feature = "concurrent")]
 pub use sharded_store::ShardedMemoryStore;
+pub use persistence::{Load, Save};
 pub use uuid;
 
 /// Prelude for convenient importing
@@ -89,6 +91,7 @@ pub mod prelude {
         error::{MemoryError, Result},
         model::{AgentProfile, AgentState, Memory},
         store::MemoryStore,
+        persistence::{Load, Save},
         #[cfg(feature = "concurrent")]
         concurrent_store::ConcurrentMemoryStore,
         #[cfg(feature = "concurrent")]
@@ -110,5 +113,8 @@ mod tests {
         let _ = AgentState::default();
         let _ = Memory::new(vec![], 0.0, 0.0, 0.0);
         let _ = MemoryStore::default();
+        // Ensure Save/Load traits are in scope
+        fn assert_save_load<T: Save + Load>() {}
+        let _ = assert_save_load::<MemoryStore>;
     }
 }

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,0 +1,47 @@
+//! Persistence utilities for saving and loading data structures.
+//!
+//! These traits provide simple file-based persistence using `serde`.
+
+use crate::error::{MemoryError, Result};
+use std::fs;
+use std::path::Path;
+
+#[cfg(feature = "serde")]
+use serde::{de::DeserializeOwned, Serialize};
+
+/// Trait for saving a value to persistent storage.
+#[cfg(feature = "serde")]
+pub trait Save {
+    /// Save the value to the specified path.
+    fn save<P: AsRef<Path>>(&self, path: P) -> Result<()>;
+}
+
+/// Trait for loading a value from persistent storage.
+#[cfg(feature = "serde")]
+pub trait Load: Sized {
+    /// Load the value from the specified path.
+    fn load<P: AsRef<Path>>(path: P) -> Result<Self>;
+}
+
+#[cfg(feature = "serde")]
+impl<T> Save for T
+where
+    T: Serialize,
+{
+    fn save<P: AsRef<Path>>(&self, path: P) -> Result<()> {
+        let data = serde_json::to_vec(self)
+            .map_err(|e| MemoryError::Serialization(e.to_string()))?;
+        fs::write(path, data).map_err(|e| MemoryError::Storage(e.to_string()))
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<T> Load for T
+where
+    T: DeserializeOwned,
+{
+    fn load<P: AsRef<Path>>(path: P) -> Result<Self> {
+        let data = fs::read(path).map_err(|e| MemoryError::Storage(e.to_string()))?;
+        serde_json::from_slice(&data).map_err(|e| MemoryError::Serialization(e.to_string()))
+    }
+}

--- a/src/store.rs
+++ b/src/store.rs
@@ -24,6 +24,12 @@ pub struct MemoryStore {
     faiss_index: Option<FaissIndex>,
 }
 
+impl Default for MemoryStore {
+    fn default() -> Self {
+        Self::new(AgentProfile::default(), AgentState::default())
+    }
+}
+
 impl MemoryStore {
     /// Creates a new [`MemoryStore`] with the given [`AgentProfile`] and [`AgentState`].
     ///

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -117,6 +117,23 @@ fn test_find_relevant_batch() {
     assert_eq!(results[1].len(), 1);
 }
 
+#[cfg(feature = "serde")]
+#[test]
+fn test_save_load_roundtrip() {
+    let profile = AgentProfile::default();
+    let state = AgentState::default();
+    let mut store = MemoryStore::new(profile, state);
+    let mem = Memory::new(vec![0.3, 0.4], 0.1, 0.0, 1.0);
+    let id = mem.id;
+    store.add_memory(mem);
+
+    let path = "./test_store.json";
+    store.save(path).unwrap();
+    let loaded: MemoryStore = Load::load(path).unwrap();
+    std::fs::remove_file(path).unwrap();
+    assert!(loaded.get_memory(&id).is_some());
+}
+
 #[cfg(feature = "concurrent")]
 #[test]
 fn test_concurrent_store_basic() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -127,10 +127,10 @@ fn test_save_load_roundtrip() {
     let id = mem.id;
     store.add_memory(mem);
 
-    let path = "./test_store.json";
-    store.save(path).unwrap();
-    let loaded: MemoryStore = Load::load(path).unwrap();
-    std::fs::remove_file(path).unwrap();
+    let temp_file = tempfile::NamedTempFile::new().unwrap();
+    store.save(temp_file.path()).unwrap();
+    let loaded: MemoryStore = Load::load(temp_file.path()).unwrap();
+    // Temporary file is automatically deleted when it goes out of scope.
     assert!(loaded.get_memory(&id).is_some());
 }
 


### PR DESCRIPTION
## Summary
- implement simple file-based `Save` and `Load` traits
- re-export traits via `prelude`
- provide `Default` for `MemoryStore`
- add roundtrip persistence test
- mark TODO item as complete

## Testing
- `cargo test --quiet` *(fails: failed to download chrono)*

------
https://chatgpt.com/codex/tasks/task_e_683e8a0015c88329a44877fbe1479241