### PR TITLE
Add database backend feature flags

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -52,7 +52,7 @@
 - [ ] Implement data format versioning for backward/forward compatibility
 
 ### 3.2 Database Integration
-- [ ] Add feature flags for different database backends (SQLite, PostgreSQL/MySQL)
+- [x] Add feature flags for different database backends (SQLite, PostgreSQL/MySQL)
 - [ ] Implement a `StorageBackend` trait for database interaction abstraction
 - [ ] Add a migration system (e.g., `sqlx-macros`, `diesel_migrations`)
 - [ ] Implement connection pooling for database connections

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ default = ["serde"]
 serde = ["dep:serde", "dep:serde_json"]
 concurrent = ["dep:dashmap"]
 faiss = ["dep:faiss"]
+sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/runtime-tokio-rustls"]
+postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/runtime-tokio-rustls"]
+mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/runtime-tokio-rustls"]
 
 [dependencies]
 # Core dependencies
@@ -30,6 +33,9 @@ ordered-float = "3.9.1"
 
 # For vector similarity search (optional)
 faiss = { version = "0.12.1", optional = true }
+
+# Database support (optional)
+sqlx = { version = "0.7", optional = true, default-features = false, features = ["macros"] }
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Rust library implementing a biologically inspired memory model for AI agents, 
 - **Configurable**: Tune parameters to model different memory profiles
 - **Efficient**: Designed for real-time use in games and interactive applications
 - **Extensible**: Easy to integrate with different storage backends and AI systems
+- **Database Backends**: Enable SQLite, PostgreSQL, or MySQL support via feature flags
 
 ## Core Concepts
 
@@ -33,6 +34,17 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 memory-module = { path = "./memory-module", features = ["serde"] }
+```
+
+Enable a database backend by adding the appropriate feature:
+
+```toml
+# SQLite
+memory-module = { path = "./memory-module", features = ["serde", "sqlite"] }
+# PostgreSQL
+memory-module = { path = "./memory-module", features = ["serde", "postgres"] }
+# MySQL
+memory-module = { path = "./memory-module", features = ["serde", "mysql"] }
 ```
 
 ### Example


### PR DESCRIPTION
## Summary
- add optional `sqlx` dependency
- introduce feature flags for SQLite, PostgreSQL and MySQL backends
- document database feature usage in README
- mark TODO item as complete

## Testing
- `cargo test --quiet` *(fails: failed to download crates)*

------
https://chatgpt.com/codex/tasks/task_e_683e8a20dfbc8329ba624f2b72b389d1