### PR TITLE
Implement Sqlite backend for storage

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -53,7 +53,7 @@
 
 ### 3.2 Database Integration
 - [x] Add feature flags for different database backends (SQLite, PostgreSQL/MySQL)
-- [ ] Implement a `StorageBackend` trait for database interaction abstraction
+- [x] Implement a `StorageBackend` trait for database interaction abstraction
 - [ ] Add a migration system (e.g., `sqlx-macros`, `diesel_migrations`)
 - [ ] Implement connection pooling for database connections
 - [ ] Utilize asynchronous database operations

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,9 @@ default = ["serde"]
 serde = ["dep:serde", "dep:serde_json"]
 concurrent = ["dep:dashmap"]
 faiss = ["dep:faiss"]
-sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/runtime-tokio-rustls"]
-postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/runtime-tokio-rustls"]
-mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/runtime-tokio-rustls"]
+sqlite = ["dep:sqlx", "sqlx/sqlite", "sqlx/runtime-tokio-rustls", "dep:tokio"]
+postgres = ["dep:sqlx", "sqlx/postgres", "sqlx/runtime-tokio-rustls", "dep:tokio"]
+mysql = ["dep:sqlx", "sqlx/mysql", "sqlx/runtime-tokio-rustls", "dep:tokio"]
 
 [dependencies]
 # Core dependencies
@@ -36,6 +36,7 @@ faiss = { version = "0.12.1", optional = true }
 
 # Database support (optional)
 sqlx = { version = "0.7", optional = true, default-features = false, features = ["macros"] }
+tokio = { version = "1", features = ["rt-multi-thread", "macros"], optional = true }
 
 [dev-dependencies]
 rstest = "0.18.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,8 @@ pub use model::{AgentProfile, AgentState, Memory};
 pub use store::MemoryStore;
 #[cfg(feature = "serde")]
 pub use storage::{FileBackend, StoredData};
+#[cfg(all(feature = "serde", feature = "sqlite"))]
+pub use storage::SqliteBackend;
 pub use storage::StorageBackend;
 #[cfg(feature = "concurrent")]
 pub use concurrent_store::ConcurrentMemoryStore;
@@ -99,6 +101,8 @@ pub mod prelude {
         StorageBackend,
         #[cfg(feature = "serde")]
         FileBackend,
+        #[cfg(all(feature = "serde", feature = "sqlite"))]
+        SqliteBackend,
         #[cfg(feature = "serde")]
         StoredData,
         #[cfg(feature = "concurrent")]


### PR DESCRIPTION
## Summary
- implement StorageBackend for a Sqlite database using sqlx
- expose `SqliteBackend` in public API and prelude
- add optional tokio dependency for database features
- mark StorageBackend trait task as complete in TODO list

## Testing
- `cargo fmt --all` *(fails: rustfmt component not installed)*
- `cargo test --quiet` *(fails: failed to fetch crates)*

------
https://chatgpt.com/codex/tasks/task_e_683f36fb47a883299acfe3a82aeab04a