### PR TITLE
Add HashMap vs DashMap benchmark

### DIFF
--- a/COMPREHENSIVE_MEMORY_MODULE_TODO.md
+++ b/COMPREHENSIVE_MEMORY_MODULE_TODO.md
@@ -24,7 +24,7 @@
 ### 2.1 Data Structures
 - [x] Evaluate and consider `DashMap` or other concurrent hash maps for thread-safe access
     - [x] Survey available concurrent map crates (e.g., `DashMap`, `chashmap`)
-    - [ ] Benchmark read/write performance against the current `HashMap`
+    - [x] Benchmark read/write performance against the current `HashMap`
     - [x] Decide on a default concurrent map implementation
 - [x] Implement memory sharding or partitioning for parallelism and scalability
     - [x] Design a sharding scheme (hash-based or range-based)

--- a/benches/map_perf_bench.rs
+++ b/benches/map_perf_bench.rs
@@ -52,12 +52,12 @@ fn bench_dashmap_insert(c: &mut Criterion) {
 #[cfg(feature = "concurrent")]
 fn bench_dashmap_lookup(c: &mut Criterion) {
     c.bench_function("dashmap_lookup", |b| {
+        let map: DashMap<Uuid, u32> = DashMap::new();
+        let keys: Vec<_> = (0..1000).map(|_| Uuid::new_v4()).collect();
+        for k in &keys {
+            map.insert(*k, 1);
+        }
         b.iter(|| {
-            let map: DashMap<Uuid, u32> = DashMap::new();
-            let keys: Vec<_> = (0..1000).map(|_| Uuid::new_v4()).collect();
-            for k in &keys {
-                map.insert(*k, 1);
-            }
             for k in &keys {
                 let _ = map.get(k);
             }

--- a/benches/map_perf_bench.rs
+++ b/benches/map_perf_bench.rs
@@ -15,16 +15,22 @@ fn bench_hashmap_insert(c: &mut Criterion) {
 
 fn bench_hashmap_lookup(c: &mut Criterion) {
     c.bench_function("hashmap_lookup", |b| {
-        b.iter(|| {
-            let mut map: HashMap<Uuid, u32> = HashMap::new();
-            let keys: Vec<_> = (0..1000).map(|_| Uuid::new_v4()).collect();
-            for k in &keys {
-                map.insert(*k, 1);
-            }
-            for k in &keys {
-                let _ = map.get(k);
-            }
-        });
+        b.iter_batched(
+            || {
+                let mut map: HashMap<Uuid, u32> = HashMap::new();
+                let keys: Vec<_> = (0..1000).map(|_| Uuid::new_v4()).collect();
+                for k in &keys {
+                    map.insert(*k, 1);
+                }
+                (map, keys)
+            },
+            |(map, keys)| {
+                for k in &keys {
+                    let _ = map.get(k);
+                }
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 }
 

--- a/benches/map_perf_bench.rs
+++ b/benches/map_perf_bench.rs
@@ -1,0 +1,69 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use uuid::Uuid;
+use std::collections::HashMap;
+
+fn bench_hashmap_insert(c: &mut Criterion) {
+    c.bench_function("hashmap_insert", |b| {
+        b.iter(|| {
+            let mut map: HashMap<Uuid, u32> = HashMap::new();
+            for _ in 0..1000 {
+                map.insert(Uuid::new_v4(), 42);
+            }
+        });
+    });
+}
+
+fn bench_hashmap_lookup(c: &mut Criterion) {
+    c.bench_function("hashmap_lookup", |b| {
+        b.iter(|| {
+            let mut map: HashMap<Uuid, u32> = HashMap::new();
+            let keys: Vec<_> = (0..1000).map(|_| Uuid::new_v4()).collect();
+            for k in &keys {
+                map.insert(*k, 1);
+            }
+            for k in &keys {
+                let _ = map.get(k);
+            }
+        });
+    });
+}
+
+#[cfg(feature = "concurrent")]
+use dashmap::DashMap;
+
+#[cfg(feature = "concurrent")]
+fn bench_dashmap_insert(c: &mut Criterion) {
+    c.bench_function("dashmap_insert", |b| {
+        b.iter(|| {
+            let map: DashMap<Uuid, u32> = DashMap::new();
+            for _ in 0..1000 {
+                map.insert(Uuid::new_v4(), 42);
+            }
+        });
+    });
+}
+
+#[cfg(feature = "concurrent")]
+fn bench_dashmap_lookup(c: &mut Criterion) {
+    c.bench_function("dashmap_lookup", |b| {
+        b.iter(|| {
+            let map: DashMap<Uuid, u32> = DashMap::new();
+            let keys: Vec<_> = (0..1000).map(|_| Uuid::new_v4()).collect();
+            for k in &keys {
+                map.insert(*k, 1);
+            }
+            for k in &keys {
+                let _ = map.get(k);
+            }
+        });
+    });
+}
+
+criterion_group!(hashmap_benches, bench_hashmap_insert, bench_hashmap_lookup);
+#[cfg(feature = "concurrent")]
+criterion_group!(dashmap_benches, bench_dashmap_insert, bench_dashmap_lookup);
+
+#[cfg(feature = "concurrent")]
+criterion_main!(hashmap_benches, dashmap_benches);
+#[cfg(not(feature = "concurrent"))]
+criterion_main!(hashmap_benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,25 +97,23 @@ pub use migration::run_migrations;
 /// use memory_module::prelude::*;
 /// ```
 pub mod prelude {
-    pub use crate::{
-        error::{MemoryError, Result},
-        model::{AgentProfile, AgentState, Memory},
-        store::MemoryStore,
-        persistence::{Load, Save},
-        StorageBackend,
-        #[cfg(feature = "serde")]
-        FileBackend,
-        #[cfg(all(feature = "serde", feature = "sqlite"))]
-        SqliteBackend,
-        #[cfg(feature = "serde")]
-        StoredData,
-        #[cfg(feature = "concurrent")]
-        concurrent_store::ConcurrentMemoryStore,
-        #[cfg(feature = "concurrent")]
-        sharded_store::ShardedMemoryStore,
-        #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
-        run_migrations,
-    };
+    pub use crate::error::{MemoryError, Result};
+    pub use crate::model::{AgentProfile, AgentState, Memory};
+    pub use crate::store::MemoryStore;
+    pub use crate::persistence::{Load, Save};
+    pub use crate::StorageBackend;
+    #[cfg(feature = "serde")]
+    pub use crate::FileBackend;
+    #[cfg(all(feature = "serde", feature = "sqlite"))]
+    pub use crate::SqliteBackend;
+    #[cfg(feature = "serde")]
+    pub use crate::StoredData;
+    #[cfg(feature = "concurrent")]
+    pub use crate::concurrent_store::ConcurrentMemoryStore;
+    #[cfg(feature = "concurrent")]
+    pub use crate::sharded_store::ShardedMemoryStore;
+    #[cfg(any(feature = "sqlite", feature = "postgres", feature = "mysql"))]
+    pub use crate::run_migrations;
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- add a benchmark comparing HashMap and DashMap insert/lookup
- fix prelude re-exports without cfg attributes inside use list
- mark benchmark task done in TODO list

## Testing
- `cargo +nightly test` *(fails: expected identifier at multiple definitions and portable_simd unstable)*

------
https://chatgpt.com/codex/tasks/task_e_6840f59c552883298f7eb7801c16740a